### PR TITLE
repalced sql password with plaintext in multi-project/site.json

### DIFF
--- a/multi-project/site.json
+++ b/multi-project/site.json
@@ -65,14 +65,7 @@
 				"settings": {
 					"database": "serviceinfo",
 					"username": "highbyte",
-					"password": {
-						"type": "Encrypted",
-						"value": {
-							"keyId": "gcqkahr8pj+67AXASPb5dw==",
-							"iv": "oXPQ/hkNS2gm/U6bgh9qhA==",
-							"ciphertext": "RzPQmgwlQZJrf3Y+q0yDtw=="
-						}
-					},
+					"password": "password",
 					"strategy": {
 						"type": "default"
 					}


### PR DESCRIPTION
The multi-project/site.json file contains a connection with an encrypted password value at `$.project.connections[name="sql"].settings.password`
We currently get this error when starting up:

```
Intelligence Hub Failed to start. Contact HighByte Support and provide the following error information:
java.lang.Exception: Failed to decrypt secrets in fragment:
        at com.highbyte.intelligencehub.runtime.deployment.c.a(Unknown Source)
        at com.highbyte.intelligencehub.runtime.deployment.c.b(Unknown Source)
        at com.highbyte.intelligencehub.runtime.a.c.e(Unknown Source)
        at com.highbyte.intelligencehub.runtime.Main.b(Unknown Source)
        at com.highbyte.intelligencehub.runtime.Main.main(Unknown Source)
```

This PR replaces that with the plaintext "password". Other options may be to add the password as plaintext into the Connection String or use Secrets alias.

```
-					"password": {
-						"type": "Encrypted",
-						"value": {
-							"keyId": "gcqkahr8pj+67AXASPb5dw==",
-							"iv": "oXPQ/hkNS2gm/U6bgh9qhA==",
-							"ciphertext": "RzPQmgwlQZJrf3Y+q0yDtw=="
-						}
-					},
+					"password": "password",
```

other options are to add it into the Connection String or use an alias:
```
"connectString": "password=password",
"password": {
  "type": "Reference",
  "value": "password"
}
```
